### PR TITLE
fix: handle never case when D[KBase] does not extend NestedRecord

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,7 +46,9 @@ export type RetrieveNested<D extends NestedRecord, P extends NestedKeys<D>> =
   P extends `${infer KBase}.${infer PNested}`
     ? D[KBase] extends Primitive
       ? D[KBase]
-      : RetrieveNested<D[KBase], PNested>
+        : D[KBase] extends NestedRecord
+        ? RetrieveNested<D[KBase], PNested>
+      : never
     : D[P];
 
 export function getNested<T extends NestedRecord, K extends NestedKeys<T>>(record: T, key: K): RetrieveNested<T, K>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES6",
     "allowJs": true,
     "moduleResolution": "node",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "types": ["jest"],
     "noEmit": true,


### PR DESCRIPTION
First off, this is a great solution to a problem I have been looking into!

I was poking around and noticed this error when using the code in one of my projects:
```
Type 'D[KBase]' does not satisfy the constraint 'NestedRecord'.
  Type 'D[string]' is not assignable to type 'NestedRecord'.
    Type 'Primitive | NestedRecord' is not assignable to type 'NestedRecord'.
      Type 'undefined' is not assignable to type 'NestedRecord'.ts(2344)

(type parameter) KBase
```

I was able to reproduce it by changing the `skipLibCheck` tsconfig setting to `false`.

To fix the issue you just have to check that `D[KBase]` extends `NestedRecord`. The `never` type seems fine here since it seems logical that `D[KBase]` should either be `Primative` or `NestedRecord`, so this is really just to tell the compiler we never expect anything else. 

Tests all pass and this is working for me locally like a charm.